### PR TITLE
ignore tweet with URL

### DIFF
--- a/genki.rb
+++ b/genki.rb
@@ -60,6 +60,8 @@ EM.run do
     log.info('status from @%s: %s' % [status.from_user, status.text])
     shinpai = '@%s ' % status.from_user
     case status.text
+    when /https?:\/\//
+      next
     when /病/
       shinpai += '病んでるの？'
     when /疲(?!れ(?:様|さ(?:ま|ん)))/


### PR DESCRIPTION
URL 付きのツイートは、URL の title を含むことが多く、意図しない励ましになるケースが多々見受けられるので無視したい。
